### PR TITLE
Fix error in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+
+      - name: Upgrade pip
         run: |
           python3.9 -m pip install --upgrade pip
 


### PR DESCRIPTION
Cannot use both `run` and `uses` in the same step. I don't think the upgrade step is necessary , but it does avoid some annoying output at times.