### PR TITLE
Fix cmd in Dockerfile

### DIFF
--- a/l1b_lambda/Dockerfile
+++ b/l1b_lambda/Dockerfile
@@ -19,4 +19,4 @@ COPY ./calibration_data /
 COPY ./level1b/handlers/level1b.py ${LAMBDA_TASK_ROOT}
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "level1b.handler" ] 
+CMD [ "level1b.lambda_handler" ] 


### PR DESCRIPTION
Command in lambda docker was pointing to a non-existent method. I have manually verified that this version can deploy and run.