### PR TITLE
Bump in- and output versions

### DIFF
--- a/l1b_lambda/app.py
+++ b/l1b_lambda/app.py
@@ -17,8 +17,8 @@ copyfile(
 Level1BStack(
     app,
     "Level1BStack",
-    input_bucket_name="ops-payload-level1a-v0.3",
-    output_bucket_name="ops-payload-level1b-v0.2",
+    input_bucket_name="ops-payload-level1a-v0.4",
+    output_bucket_name="ops-payload-level1b-v0.3",
 )
 
 app.synth()


### PR DESCRIPTION

Bumps versions in anticipation of new partitioning. Note that buckets will need to be created.
We should also empty the DLQ.