### PR TITLE
Convert calibrated image to list before storing

### DIFF
--- a/l1b_lambda/level1b/handlers/level1b.py
+++ b/l1b_lambda/level1b/handlers/level1b.py
@@ -119,6 +119,9 @@ def lambda_handler(event: Event, context: Context):
         ], axis=1).set_index("EXPDate").sort_index()
         l1b_data.drop(["ImageData", "Errors", "Warnings"], axis=1, inplace=True)
         l1b_data = l1b_data[l1b_data.ImageCalibrated != None]  # noqa: E711
+        l1b_data["ImageCalibrated"] = [
+            ic.tolist() for ic in l1b_data["ImageCalibrated"]
+        ]
 
         out_table = pa.Table.from_pandas(l1b_data)
         pq.write_table(

--- a/l1b_lambda/level1b/handlers/level1b.py
+++ b/l1b_lambda/level1b/handlers/level1b.py
@@ -122,6 +122,9 @@ def lambda_handler(event: Event, context: Context):
         l1b_data["ImageCalibrated"] = [
             ic.tolist() for ic in l1b_data["ImageCalibrated"]
         ]
+        l1b_data["CalibrationErrors"] = [
+            int(ce) for ce in l1b_data["CalibrationErrors"]
+        ]
     except Exception as err:
         msg = f"Failed to prepare {object_path} for storage: {err}"
         raise Level1BException(msg) from err

--- a/l1b_lambda/level1b/handlers/level1b.py
+++ b/l1b_lambda/level1b/handlers/level1b.py
@@ -122,7 +122,11 @@ def lambda_handler(event: Event, context: Context):
         l1b_data["ImageCalibrated"] = [
             ic.tolist() for ic in l1b_data["ImageCalibrated"]
         ]
+    except Exception as err:
+        msg = f"Failed to prepare {object_path} for storage: {err}"
+        raise Level1BException(msg) from err
 
+    try:
         out_table = pa.Table.from_pandas(l1b_data)
         pq.write_table(
             out_table,

--- a/l1b_lambda/level1b/handlers/level1b.py
+++ b/l1b_lambda/level1b/handlers/level1b.py
@@ -123,7 +123,7 @@ def lambda_handler(event: Event, context: Context):
             ic.tolist() for ic in l1b_data["ImageCalibrated"]
         ]
         l1b_data["CalibrationErrors"] = [
-            ce.toloist() for ce in l1b_data["CalibrationErrors"]
+            ce.tolist() for ce in l1b_data["CalibrationErrors"]
         ]
     except Exception as err:
         msg = f"Failed to prepare {object_path} for storage: {err}"

--- a/l1b_lambda/level1b/handlers/level1b.py
+++ b/l1b_lambda/level1b/handlers/level1b.py
@@ -123,7 +123,7 @@ def lambda_handler(event: Event, context: Context):
             ic.tolist() for ic in l1b_data["ImageCalibrated"]
         ]
         l1b_data["CalibrationErrors"] = [
-            int(ce) for ce in l1b_data["CalibrationErrors"]
+            ce.toloist() for ce in l1b_data["CalibrationErrors"]
         ]
     except Exception as err:
         msg = f"Failed to prepare {object_path} for storage: {err}"


### PR DESCRIPTION
This converts the calibrated image to a nested list before storing it. For some reason 2d-arrays don't work out of the box, but this seems to do...

Calibration Errors need the same treatment, apparently.


Resolves #100 