### PR TITLE
Set force_table=False in Lambda processing

### DIFF
--- a/l1b_lambda/level1b/handlers/level1b.py
+++ b/l1b_lambda/level1b/handlers/level1b.py
@@ -101,7 +101,7 @@ def lambda_handler(event: Event, context: Context):
                     _,
                     image_calibrated,
                     errors,
-                ) = L1_calibrate(ccd, instrument)
+                ) = L1_calibrate(ccd, instrument, force_table=False)
             ccd["ImageCalibrated"] = image_calibrated
             ccd["CalibrationErrors"] = errors
     except Exception as err:

--- a/src/mats_l1_processing/L1_calibrate.py
+++ b/src/mats_l1_processing/L1_calibrate.py
@@ -55,7 +55,7 @@ def calibrate_all_items(CCDitems, instrument, plot=False):
             fig.suptitle(CCDitem["channel"])
 
 
-def L1_calibrate(CCDitem, instrument): #This used to take in a calibration_file instread of instrument object 
+def L1_calibrate(CCDitem, instrument, force_table: bool = True):  # This used to take in a calibration_file instread of instrument object
 
     CCDitem["CCDunit"] =instrument.get_CCD(CCDitem["channel"])
 
@@ -68,7 +68,7 @@ def L1_calibrate(CCDitem, instrument): #This used to take in a calibration_file 
 
     # step 3: correct for non-linearity (image is converted into float??)
 
-    image_linear,error_flags_linearity = get_linearized_image(CCDitem, image_bias_sub)
+    image_linear,error_flags_linearity = get_linearized_image(CCDitem, image_bias_sub, force_table)
 
     # Step 4: Desmear
     image_desmeared, error_flags_desmear= desmear_true_image(CCDitem, image_linear)

--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -321,13 +321,13 @@ def lin_image_from_inverse_model_real(image_bias_sub,CCDitem):
 
     return image_linear,error_flag
 
-def get_linearized_image(CCDitem, image_bias_sub,force_table: bool = False):
+def get_linearized_image(CCDitem, image_bias_sub, force_table: bool = True):
     """ Linearizes the image. At the moment not done for NADIR.
 
     Args:
         CCDitem:  dictonary containing CCD image and information
         image: np.array The image that will be linearised
-        force_table (bool): whether to force table generation if no exists (default=False)
+        force_table (bool): whether to force table generation if no exists (default=True)
 
     Returns: 
         image_linear (np.array, dtype=float64): linearised number of counts

--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -321,13 +321,13 @@ def lin_image_from_inverse_model_real(image_bias_sub,CCDitem):
 
     return image_linear,error_flag
 
-def get_linearized_image(CCDitem, image_bias_sub,force_table = True):
+def get_linearized_image(CCDitem, image_bias_sub,force_table: bool = False):
     """ Linearizes the image. At the moment not done for NADIR.
 
     Args:
         CCDitem:  dictonary containing CCD image and information
         image: np.array The image that will be linearised
-        force_table (bool): whether to force table generation if no exists (default=True)
+        force_table (bool): whether to force table generation if no exists (default=False)
 
     Returns: 
         image_linear (np.array, dtype=float64): linearised number of counts


### PR DESCRIPTION
This propagates the `force_table` argument from `get_linearized_image` to `L1_calibrate` and sets it to `False` for Lambda batch-processing, where the file system is read only.

I'm not sure if this will ruin something else in your workflows, @innosat-mats/scientific . I don't think so, but please review carefully!

Resolves #103 