### PR TITLE
Propagate qprime

### DIFF
--- a/l1b_lambda/level1b/handlers/level1b.py
+++ b/l1b_lambda/level1b/handlers/level1b.py
@@ -111,7 +111,12 @@ def lambda_handler(event: Event, context: Context):
     try:
         calibrated = DataFrame.from_records(
             ccd_items,
-            columns=["EXP Date", "ImageCalibrated", "CalibrationErrors"],
+            columns=[
+                "EXP Date",
+                "ImageCalibrated",
+                "CalibrationErrors",
+                "qprime",
+            ],
         )
         l1b_data = concat([
             ccd_data,


### PR DESCRIPTION
This propagates `qprime` to the L1B record. This fixes the code part of #106, but the data will need to be re-run. That should probably wait until after #101 and #107 have been merged as well, though.