### PR TITLE
corrections to desmear and lin method

### DIFF
--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -781,16 +781,16 @@ def desmear(image, nrskip, exptimeratio, fill=None):
     nrow, ncol = image.shape
     nr = nrow+nrskip
     weights = np.tril(
-        exptimeratio*np.ones([nr, nr]), -(nrskip+1))+np.diag(np.ones([nr]))
+        exptimeratio*np.ones([nr, nr]), -1)+np.diag(np.ones([nr]))
     if nrskip > 0:
-        extimage = np.vstack((fill, image))
+        extimage = np.vstack((fill, image)) 
     else:
         extimage = image
+    desmeared=linalg.solve(weights, extimage)
+    return desmeared[nrskip:, :]
 
-    return (linalg.solve(weights, extimage)[nrskip:, :])
 
-
-def desmear_true_image(header, image=None, fill_method='exp_row', **kwargs):
+def desmear_true_image(header, image=None, fill_method='lin_row', **kwargs):
     """Subtracts the smearing (due to no shutter) from the image.
 
     Args:
@@ -808,19 +808,26 @@ def desmear_true_image(header, image=None, fill_method='exp_row', **kwargs):
     nrow = int(header["NROW"])
     ncol = int(header["NCOL"]) + 1
     nrskip = int(header["NRSKIP"])
+    nrbin = int(header["NRBIN"])
     # calculate extra time per row
     T_row_extra, T_delay = calculate_time_per_row(header)
 
     T_exposure = float(header["TEXPMS"]) / 1000.0
     if fill_method == "exp_row":
-        H = 10/0.15/header["NRBIN"]
-        fill_function = np.expand_dims(np.exp((np.arange(nrskip)+1)[::-1]/H), axis=1)
+        H = 1/np.log(np.median(image[1,:])/np.median(image[2,:]))
+        fill_function = np.expand_dims(np.exp((np.arange(nrskip/nrbin)+1)[::-1]/H), axis=1)
         fill_array = fill_function * \
-            np.repeat(np.expand_dims(image[0, :], axis=1), nrskip, axis=1).T
+            np.repeat(np.expand_dims(image[0, :], axis=1), fill_function.shape[0], axis=1).T
+    elif fill_method == "lin_row":
+        #make a rough correction for the fact row 2 has some row 1 in it
+        grad=(1 - T_row_extra /T_exposure)*(np.median(image[1,:])-np.median(image[2,:]))
+        fill_function = np.expand_dims(grad*((np.arange(nrskip/nrbin)+1)[::-1]), axis=1)
+        fill_array = fill_function + \
+            np.repeat(np.expand_dims(image[0, :], axis=1), fill_function.shape[0], axis=1).T       
     else:
         raise Exception("Fill method invalid")
 
-    image = desmear(image, nrskip=nrskip, exptimeratio=T_row_extra /
+    image = desmear(image, nrskip=fill_function.shape[0], exptimeratio=T_row_extra /
                     T_exposure, fill=fill_array)
 
     # row 0 here is the first row to read out from the chip


### PR DESCRIPTION
Updated desmear so as to add the correct number for filling rows depending on NRBIN.
Should note that it would be more correct if nrskip were a multiple of nrbin - we can now have partial binned rows.  The indexing takes care of this if somewhat crudely.  

Exponential extrapolation can give negative values in IR3 and IR4 so a linear extrapolation has been added and made to be default.  Can sometimes give negative values above 90 km- I think we can live with it

UV1 can look weird in crop4 but this is Lindas flat field and not the desmearing.   Hopefully this will be gone when she makes better ones. 

I had a look at trying to make default filling from non cropped data but the variation is too large to make this easy - requires more work. 