### PR TITLE
fixing nrskip in tril matrix (had changed wrongly

### DIFF
--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -781,7 +781,7 @@ def desmear(image, nrskip, exptimeratio, fill=None):
     nrow, ncol = image.shape
     nr = nrow+nrskip
     weights = np.tril(
-        exptimeratio*np.ones([nr, nr]), -1)+np.diag(np.ones([nr]))
+        exptimeratio*np.ones([nr, nr]), -(nrskip+1))+np.diag(np.ones([nr]))
     if nrskip > 0:
         extimage = np.vstack((fill, image)) 
     else:


### PR DESCRIPTION
Let myself get confused by Lindas non-flat fields and made an incorrect change-

Minor effect (might be more if using exp) but better to have it correct  