### PR TITLE
fix to desmear for cropped images

### DIFF
--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -779,15 +779,17 @@ def desmear(image, nrskip, exptimeratio, fill=None):
     """
 
     nrow, ncol = image.shape
-    nr = nrow+nrskip
+    nr = nrow-nrskip
     weights = np.tril(
-        exptimeratio*np.ones([nr, nr]), -(nrskip+1))+np.diag(np.ones([nr]))
+        exptimeratio*np.ones([nrow, nrow]), -(nrskip+1))+np.diag(np.ones([nrow]))
     if nrskip > 0:
-        extimage = np.vstack((fill, image)) 
+        extimage = image - \
+            np.tril(exptimeratio*np.ones([nrow, nrow]), -
+                    1) @ np.vstack((fill, np.zeros([nr, ncol])))
     else:
         extimage = image
-    desmeared=linalg.solve(weights, extimage)
-    return desmeared[nrskip:, :]
+    desmeared = linalg.solve(weights, extimage)
+    return desmeared
 
 
 def desmear_true_image(header, image=None, fill_method='lin_row', **kwargs):


### PR DESCRIPTION
discovered that we had a conceptual problem in the filling and how it should be used. I don't think the previous version of the de-smear did anything at higher altitudes.

This version treats the fill and the remaining data in a correct manner. 
Some negative values night time seen in my tests but to be expected. 
Could remain a 1 line error in the indexing 
Suggest putting this through and letting it run over the weekend -  so we can check larger amounts of data 
 