### PR TITLE
Changed indexing of read_ccd_data_in_interval

### DIFF
--- a/src/mats_l1_processing/read_parquet_functions.py
+++ b/src/mats_l1_processing/read_parquet_functions.py
@@ -231,7 +231,11 @@ def read_ccd_data_in_interval(
         path,
         filesystem=filesystem,
     ).to_table(filter=filterlist)
-    dataframe = table.to_pandas().reset_index().set_index('TMHeaderTime')
+    dataframe = table.to_pandas()
+    dataframe.set_index('TMHeaderTime')
+    dataframe.sort_index()
+    dataframe.reset_index(inplace=True)
+
     if metadata:
         return dataframe, table.schema.metadata
     return dataframe


### PR DESCRIPTION
Indexing was implicitly done on `EXPDate` (or `TMHeaderTime`) before, this caused some strange behaviour if you wanted to do some things, e.g. it would not show up in df.columns. Now sorting is done on `TMHeaderTime` but index is set to simple numerical index before the dataframe is returned. 