### PR TITLE
Add `inplace=True` to `sort_index`

### DIFF
--- a/src/mats_l1_processing/read_parquet_functions.py
+++ b/src/mats_l1_processing/read_parquet_functions.py
@@ -234,7 +234,7 @@ def read_ccd_data_in_interval(
     dataframe = table.to_pandas()
     dataframe.reset_index(inplace=True)
     dataframe.set_index('TMHeaderTime',inplace=True)
-    dataframe.sort_index()
+    dataframe.sort_index(inplace=True)
     dataframe.reset_index(inplace=True)
 
     if metadata:


### PR DESCRIPTION
From the documentation:
```
Sort object by labels (along an axis).

Returns a new DataFrame sorted by label if `inplace` argument is
``False``, otherwise updates the original DataFrame and returns None.

...

inplace : bool, default False
    Whether to modify the DataFrame rather than creating a new one.
```
That is to say, without `inplace=True` this line only produces waste heat.