### PR TITLE
Artifact correction

### DIFF
--- a/src/mats_l1_processing/L1_calibrate.py
+++ b/src/mats_l1_processing/L1_calibrate.py
@@ -106,6 +106,6 @@ def L1_calibrate(CCDitem, instrument, force_table: bool = True):  # This used to
 
     errors = combine_flags([error_bad_column,error_flags_bias,error_flags_linearity,error_flags_desmear,
     error_flags_dark,error_flags_flatfield,error_ghost,error_artifact],
-    [1,1,2,1,3,2,1,1])
+    [1,1,2,1,3,2,1,2])
     
     return image_lsb, image_bias_sub, image_desmeared, image_dark_sub, image_calib_nonflipped, image_calibrated_flipped, image_calibrated, errors

--- a/src/mats_l1_processing/L1_calibrate.py
+++ b/src/mats_l1_processing/L1_calibrate.py
@@ -17,7 +17,8 @@ from mats_l1_processing.L1_calibration_functions import (
     combine_flags,
     make_binary,
     flip_image,
-    handle_bad_columns)
+    handle_bad_columns,
+    artifact_correction)
 from mats_l1_processing.pointing import add_channel_quaternion
 
 
@@ -41,17 +42,18 @@ def calibrate_all_items(CCDitems, instrument, plot=False):
             image_dark_sub,
             image_calib_nonflipped,
             image_calibrated,
-            image_common_fov,
+            image_calib_no_art,
             errors,
         ) = L1_calibrate(CCDitem, instrument)
 
         if plot == True:
-            fig, ax = plt.subplots(5, 1)
+            fig, ax = plt.subplots(6, 1)
             plot_CCDimage(image_lsb, fig, ax[0], "Original LSB")
             plot_CCDimage(image_bias_sub, fig, ax[1], "Bias subtracted")
             plot_CCDimage(image_desmeared, fig, ax[2], " Desmeared LSB")
             plot_CCDimage(image_dark_sub, fig, ax[3], " Dark current subtracted LSB")
             plot_CCDimage(image_calib_nonflipped, fig, ax[4], " Flat field compensated LSB")
+            plot_CCDimage(image_calib_no_art, fig, ax[5], "Artifact corrected LSB (only for nadir)")
             fig.suptitle(CCDitem["channel"])
 
 
@@ -59,6 +61,7 @@ def L1_calibrate(CCDitem, instrument, force_table: bool = True):  # This used to
 
     CCDitem["CCDunit"] =instrument.get_CCD(CCDitem["channel"])
 
+    
     error_bad_column=handle_bad_columns(CCDitem)
 
     image_lsb = CCDitem["IMAGE"]
@@ -83,7 +86,7 @@ def L1_calibrate(CCDitem, instrument, force_table: bool = True):  # This used to
     image_calib_nonflipped, error_flags_flatfield = flatfield_calibration(CCDitem, image_dark_sub)
     
     # Flip image for IR2 and IR4
-    image_calibrated= flip_image(CCDitem, image_calib_nonflipped)
+    image_calibrated_flipped= flip_image(CCDitem, image_calib_nonflipped)
     
     # Add channel quaterion to image
     add_channel_quaternion(CCDitem)
@@ -95,11 +98,14 @@ def L1_calibrate(CCDitem, instrument, force_table: bool = True):  # This used to
     error_ghost =  make_binary(np.zeros(CCDitem["IMAGE"].shape,dtype=np.uint16),1)
 
     # Step 8 Transform from LSB to electrons and then to photons. TBD.
-    
+
+    # Step 9 Remove artifact from nadir images
+    image_calibrated, error_artifact = artifact_correction(CCDitem,image_calibrated_flipped)
+
     CCDitem["image_calibrated"] = image_calibrated
 
     errors = combine_flags([error_bad_column,error_flags_bias,error_flags_linearity,error_flags_desmear,
-    error_flags_dark,error_flags_flatfield,error_ghost],
-    [1,1,2,1,3,2,1])
+    error_flags_dark,error_flags_flatfield,error_ghost,error_artifact],
+    [1,1,2,1,3,2,1,1])
     
-    return image_lsb, image_bias_sub, image_desmeared, image_dark_sub, image_calib_nonflipped, image_calibrated, errors
+    return image_lsb, image_bias_sub, image_desmeared, image_dark_sub, image_calib_nonflipped, image_calibrated_flipped, image_calibrated, errors

--- a/src/mats_l1_processing/instrument.py
+++ b/src/mats_l1_processing/instrument.py
@@ -319,6 +319,15 @@ class CCD:
                             'formats':('S5','f4','f4','f4','f4')})
         self.qprime = np.array([(d['q0'],d['q1'],d['q2'],d['q3']) for d in qprimes if d['Channel'].decode('utf8')==self.channel][0])
 
+        # artifact correction
+        if channel=="NADIR":
+            filename = calibration_data['artifact']['nadir']
+            self.artifact_masks = pd.read_pickle(filename)
+            
+        else :        
+            filename = calibration_data['artifact']['blank']
+            self.artifact_masks = pd.read_pickle(filename)
+
                 
     def calib_denominator(self, mode): 
         """Get calibration constant that should be divided by to get unit 10^10 ph cm-2 s-1 str-1 nm-1.
@@ -481,6 +490,16 @@ class CCD:
             quaternion
         """
         return self.qprime
+
+    def get_artifact_mask(self):
+        """Read the artifact masks from file
+        Args:
+            CCDitem (dict): Dictionary of type CCDitem
+
+        Returns:
+            artifact_masks (dataframe): panda dataframe containing the masks correcting for the artifact in nadir images
+        """
+        return self.artifact_masks
 
 class nonLinearity:
     """Class to represent a non-linearity for a MATS CCD.

--- a/tests/calibration_data_test.toml
+++ b/tests/calibration_data_test.toml
@@ -30,4 +30,7 @@ title = "Level 1 calibration files for testing this package"
 	abs_rel_calib_constants= "calibration_data/abs_rel_calib/abs_rel_calib_constants.csv"
 [pointing]
     qprime = 'calibration_data/pointing/'
+[artifact]
+    nadir = 'calibration_data/artifact/nadir_correction_masks.pk1'
+    blank = 'calibration_data/artifact/blank_mask.pk1'
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -209,24 +209,24 @@ def test_artifact():
     #ccd channel other than NADIR shouldn't be modified
     image = CCDitem_IR2['IMAGE']
     image_no_artifact, error_artifact = artifact_correction(CCDitem_IR2)
-    assert abs(np.sum(image_no_artifact -  image))<1e-9
+    np.testing.assert_allclose(image_no_artifact,image,atol=1e-9)
     expected_error_flag = np.full(np.shape(image),2,dtype=np.uint16)
-    assert abs(np.sum(expected_error_flag-error_artifact))<1e-9
+    np.testing.assert_allclose(expected_error_flag,error_artifact,atol=1e-9)
 
     
     image = CCDitem_nadir['IMAGE']
     image_expected = np.load('testdata/artifact_correction/image_artifact_corrected.npy')
     error_expected =  np.load('testdata/artifact_correction/artifact_error.npy')
     image_no_artifact, error_artifact = artifact_correction(CCDitem_nadir)
-    assert abs(np.sum(image_no_artifact -  image_expected))<1e-9
-    assert abs(np.sum(error_expected-error_artifact))<1e-9
+    np.testing.assert_allclose(image_no_artifact,image_expected,atol=1e-9)
+    np.testing.assert_allclose(error_expected,error_artifact,atol=1e-9)
 
     image = np.load('testdata/artifact_correction/image_artifact.npy')
     image_expected = np.load('testdata/artifact_correction/image_artifact_corrected2.npy')
     error_expected =  np.load('testdata/artifact_correction/artifact_error.npy')
     image_no_artifact, error_artifact = artifact_correction(CCDitem_nadir,image)
-    assert abs(np.sum(image_expected -  image_no_artifact))<1e-9
-    assert abs(np.sum(error_expected-error_artifact))<1e-9
+    np.testing.assert_allclose(image_expected,image_no_artifact,atol=1e-9)
+    np.testing.assert_allclose(error_expected,error_artifact,atol=1e-9)
 
 
     

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -206,11 +206,12 @@ def test_artifact():
     
     
 
-    # ccd channel other than NADIR shouldn't be modified
-    # image = CCDitem_IR2['IMAGE']
-    # image_no_artifact, error_artifact = artifact_correction(CCDitem_IR2)
-    # assert abs(np.sum(image_no_artifact -  image))<1e-9
-    # assert abs(np.sum(np.zeros_like(image)-error_artifact))<1e-9
+    #ccd channel other than NADIR shouldn't be modified
+    image = CCDitem_IR2['IMAGE']
+    image_no_artifact, error_artifact = artifact_correction(CCDitem_IR2)
+    assert abs(np.sum(image_no_artifact -  image))<1e-9
+    expected_error_flag = np.full(np.shape(image),2,dtype=np.uint16)
+    assert abs(np.sum(expected_error_flag-error_artifact))<1e-9
 
     
     image = CCDitem_nadir['IMAGE']

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -2,7 +2,7 @@ import pytest
 
 from mats_l1_processing.read_and_calibrate_all_files_parallel import main
 from mats_l1_processing.instrument import Instrument, CCD
-from mats_l1_processing.L1_calibration_functions import inverse_model_real,inverse_model_table,make_binary,combine_flags,desmear
+from mats_l1_processing.L1_calibration_functions import inverse_model_real,inverse_model_table,make_binary,combine_flags,desmear,artifact_correction
 
 import pickle
 import numpy as np
@@ -83,6 +83,7 @@ def test_CCDunit():
 def test_non_linearity_fullframe():
     with open('testdata/CCDitem_example.pkl', 'rb') as f:
         CCDitem = pickle.load(f)
+        
     
     with open('testdata/CCDunit_IR1_example.pkl', 'rb') as f:
         CCDunit_IR1=pickle.load(f)        
@@ -187,6 +188,49 @@ def test_desmearing():
     assert np.sum(corrected_image -  input_array[nrskip:])<1e-9
 
 
+
+def test_artifact():
+
+    with open('testdata/artifact_correction/CCDitem_artifact_IR2.pkl', 'rb') as f:
+        CCDitem_IR2 = pickle.load(f)
+
+    with open('testdata/artifact_correction/CCDitem_artifact_NADIR.pkl', 'rb') as f:
+        CCDitem_nadir = pickle.load(f)
+
+    instrument = Instrument("tests/calibration_data_test.toml")
+    CCDunit_IR2=instrument.get_CCD("IR2")
+    CCDitem_IR2['CCDunit']=CCDunit_IR2
+    CCDunit_nadir=instrument.get_CCD("NADIR")
+    CCDitem_nadir['CCDunit']=CCDunit_nadir
+    
+    
+    
+
+    # ccd channel other than NADIR shouldn't be modified
+    # image = CCDitem_IR2['IMAGE']
+    # image_no_artifact, error_artifact = artifact_correction(CCDitem_IR2)
+    # assert abs(np.sum(image_no_artifact -  image))<1e-9
+    # assert abs(np.sum(np.zeros_like(image)-error_artifact))<1e-9
+
+    
+    image = CCDitem_nadir['IMAGE']
+    image_expected = np.load('testdata/artifact_correction/image_artifact_corrected.npy')
+    error_expected =  np.load('testdata/artifact_correction/artifact_error.npy')
+    image_no_artifact, error_artifact = artifact_correction(CCDitem_nadir)
+    assert abs(np.sum(image_no_artifact -  image_expected))<1e-9
+    assert abs(np.sum(error_expected-error_artifact))<1e-9
+
+    image = np.load('testdata/artifact_correction/image_artifact.npy')
+    image_expected = np.load('testdata/artifact_correction/image_artifact_corrected2.npy')
+    error_expected =  np.load('testdata/artifact_correction/artifact_error.npy')
+    image_no_artifact, error_artifact = artifact_correction(CCDitem_nadir,image)
+    assert abs(np.sum(image_expected -  image_no_artifact))<1e-9
+    assert abs(np.sum(error_expected-error_artifact))<1e-9
+
+
+    
+
+
 def test_calibration_output():
     
     from mats_l1_processing.L1_calibration_functions import (
@@ -194,7 +238,8 @@ def test_calibration_output():
         desmear_true_image,
         subtract_dark,
         flatfield_calibration,
-        get_linearized_image
+        get_linearized_image,
+        artifact_correction
     )
     
    # from mats_l1_processing.read_in_functions import read_CCDitems    
@@ -216,14 +261,23 @@ def test_calibration_output():
     image_dark_sub, error_flags_dark = subtract_dark(CCDitem, image_desmeared)
 
     image_calib_nonflipped, error_flags_flatfield = flatfield_calibration(CCDitem, image_dark_sub)
+
+
+    # no test for image flipping yet
+    image_calibrated_flipped = image_calib_nonflipped
+
+    image_calibrated, error_artifact = artifact_correction(CCDitem,image_calibrated_flipped)
     
     with open('testdata/calibration_output.pkl', 'rb') as f:
-            [image_bias_sub_old, image_desmeared_old, image_dark_sub_old, image_calib_nonflipped_old]=pickle.load(f)
+            [image_bias_sub_old, image_desmeared_old, image_dark_sub_old, image_calib_nonflipped_old, image_no_artifact_old]=pickle.load(f)
     
     assert np.abs(image_bias_sub_old-image_bias_sub).all()<1e-3
     assert np.abs(image_desmeared_old-image_desmeared).all()<1e-3
     assert np.abs(image_dark_sub_old-image_dark_sub).all()<1e-3
     #assert np.abs(image_calib_nonflipped_old-image_calib_nonflipped).all()<1e-3
+    assert np.abs(image_no_artifact_old-image_calibrated).all()<1e-3
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
adding a function applying a correction to nadir images in order to remove the artifact. The correction data is dependent on the solar azimuth angle and stored in a .pkl file. 
the error_flag weaker bit shows if a correction has been applied to a specific pixel
if the correction masks don't have the same shape as the images, if the channel is not nadir or if the correction failed, the strongest bits in the error flag equal to one. 