### PR TITLE
Remove spurious import

### DIFF
--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -78,8 +78,6 @@ def combine_flags(flags, bits):
 
     """
 
-    import numpy as np
-
     if len(flags) != len(bits):
         raise ValueError('number of bit values differ from number of flag arrays')
 


### PR DESCRIPTION
`import numpy as np` is already done up top, unnecessary and possibly wasteful to import it again.