### PR TITLE
Bump instrument

### DIFF
--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -369,8 +369,14 @@ def get_linearized_image(CCDitem, image_bias_sub, force_table: bool = True):
                 image_linear, error_flag = lin_image_from_inverse_model_table(
                     image_bias_sub, table)
             else:
-                image_linear, error_flag = lin_image_from_inverse_model_real(
-                    image_bias_sub, CCDitem)
+                try:
+                    raise ValueError(
+                        f"No table for CCD item {CCDitem['ImageName']}"
+                    )
+                except KeyError:
+                    raise ValueError(
+                        f"No table for CCD item {CCDitem['ImageFileName']}"
+                    )
 
     error_flag = make_binary(error_flag, 2)
 


### PR DESCRIPTION
Bump instrument data and make processing fail early when table data is missing.

I don't think this change will impact the manual work-flows, since the flag is `True` by default, but please check!