### PR TITLE
Fix bytes metadata names

### DIFF
--- a/l1b_lambda/level1b/handlers/level1b.py
+++ b/l1b_lambda/level1b/handlers/level1b.py
@@ -157,7 +157,9 @@ def lambda_handler(event: Event, context: Context):
 
     try:
         for key, val in metadata.items():
-            l1b_data[key.encode()] = val.encode()
+            l1b_data[
+                key if isinstance(key, str) else key.encode()
+            ] = val if isinstance(val, str) else val.encode()
         out_table = pa.Table.from_pandas(l1b_data)
         out_table = out_table.replace_schema_metadata({
             **metadata,

--- a/l1b_lambda/level1b/handlers/level1b.py
+++ b/l1b_lambda/level1b/handlers/level1b.py
@@ -156,8 +156,8 @@ def lambda_handler(event: Event, context: Context):
         raise Level1BException(msg) from err
 
     try:
-        for key in metadata.keys():
-            l1b_data[key] = metadata[key]
+        for key, val in metadata.items():
+            l1b_data[key.encode()] = val.encode()
         out_table = pa.Table.from_pandas(l1b_data)
         out_table = out_table.replace_schema_metadata({
             **metadata,


### PR DESCRIPTION
When reading metadata from file header, the resulting keys and values are `bytes`, however, the columns in the dataset are strings. This lead to the updating of the metadata creating semi-duplicated column names instead of updating the existing, since _e.g._ `b"INNOSAT" != "INNOSAT"`. When saving as dataset all columns were saved, but either there, or when reading, all columns were converted to string, which caused actual duplicated columns, resulting in an unreadable dataset.

This encodes the keys and values if necessary, which should avoid the problem.