### PR TITLE
Added a 3 point median filter to the dark current images in order to …

### DIFF
--- a/src/database_generation/experimental_utils.py
+++ b/src/database_generation/experimental_utils.py
@@ -26,7 +26,7 @@ def plotCCDitem(CCDitem, fig, axis, title="", clim=999, aspect="auto", altvec=No
     return sp
 
 
-def plot_CCDimage(image, fig=None, axis=None, title="", clim=None, aspect="auto", altvec=None):
+def plot_CCDimage(image, fig=None, axis=None, title="", clim=None, aspect="auto", altvec=None, borders=False, nrsig=2):
     """Plots a CCD image in a figure, 
     note that optional argument altvec ONLY specifies the upper and lower limit of the y-axis,
     not the actual altitudes of the image"""
@@ -51,10 +51,15 @@ def plot_CCDimage(image, fig=None, axis=None, title="", clim=None, aspect="auto"
 
     if clim==None:
         [col, row]=image.shape
-        #Take the mean and std of the middle of the image, not boarders
-        mean = image[int(col/2-col*4/10):int(col/2+col*4/10), int(row/2-row*4/10):int(row/2+row*4/10)].mean()
-        std = image[int(col/2-col*4/10):int(col/2+col*4/10), int(row/2-row*4/10):int(row/2+row*4/10)].std()
-        sp.set_clim([mean - 2 * std, mean + 2 * std])
+        if borders:
+            #Take the mean and std of the middle of the image,including borders
+            mean=image.mean()
+            std=image.std()
+        else:
+            #Take the mean and std of the middle of the image, not boarders
+            mean = image[int(col/2-col*4/10):int(col/2+col*4/10), int(row/2-row*4/10):int(row/2+row*4/10)].mean()
+            std = image[int(col/2-col*4/10):int(col/2+col*4/10), int(row/2-row*4/10):int(row/2+row*4/10)].std()
+        sp.set_clim([mean - nrsig * std, mean + nrsig * std])
     else:
         sp.set_clim(clim)
     fig.colorbar(sp, ax=axis)

--- a/src/database_generation/flatfield.py
+++ b/src/database_generation/flatfield.py
@@ -67,13 +67,15 @@ def read_flatfield(CCDunit, mode, flatfield_directory):
 
 def scale_field(field):
     # Now scale the average of the middle part of the flatfield with baffle
-    # to be the same as the average of flatfield_wo_baffle_lin_scaled .
+    # to be unity.
 
-    # # The values of the below should give an area not affected by the baffle
-    FirstRow = 350 #100
-    LastRow = 400 #400
-    FirstCol =400 #200
-    LastCol =1600 #1850
+    # # The values of the below should give an area not affected by the baffle and is the area that the 
+    # calibration factors from the lab is defined by
+
+    FirstRow = 350 
+    LastRow = 400 
+    FirstCol =524
+    LastCol =1523
 
     field_scaled =field/field[FirstRow:LastRow, FirstCol + 1 : LastCol + 1].mean()
 

--- a/src/mats_l1_processing/instrument.py
+++ b/src/mats_l1_processing/instrument.py
@@ -164,9 +164,6 @@ class CCD:
         self.default_temp = calibration_data["darkcurrent"]["default_temp"]
         # Limit to choose 1D or 2D dark current subtraction
         self.dc_2D_limit=calibration_data["darkcurrent"]["dc_2D_limit"]
-        if self.dc_2D_limit!=0: 
-            # Raising hte below error since thresholds are yet to be decided  upon LM 20220928
-            raise NotImplementedError('Only threshold of zero supported')
 
         # Read in Gabriels calibration data from a .mat file
         filename = (


### PR DESCRIPTION
- L1_calibration_functions.py @@ -553,7 +553,7 @@ def calculate_dark(CCDitem): Added a 3 point median filter to the dark current images in order to not double compensate for hot pixels in the L1a to L1b calibration chain.  Fixed bug in criterium of when bin_image_with_BC is used (should be when no NRSKIP and NCSKIP)
- flatfield.py Changed the area that was defined to be unity in the calibration, to agree exactly to what was used on the ground calibration (should have very limeted effect). 
- experimental_utils.py Added some optional functionality to plotting function plot_CCDitem
- instrument.py Removed error message if  if self.dc_2D_limit!=0: