### PR TITLE
Fixed bug in L1_calibration functions

### DIFF
--- a/src/database_generation/run_make_flatfield.py
+++ b/src/database_generation/run_make_flatfield.py
@@ -28,10 +28,10 @@ for channel in channels:
      #Note, only using HSM mode images for making flatfield now LM230925
     flatfield_morphed=flatfield.make_flatfield(channel, calibration_file, plotresult=True, plotallplots=True)
     Path("output").mkdir(parents=True, exist_ok=True)
-    #np.savetxt('output/flatfield_'+channel+'_HSM.csv', flatfield_morphed)
-    #np.save('output/flatfield_'+channel+'_HSM.npy', flatfield_morphed)
+    np.savetxt('output/flatfield_'+channel+'_HSM.csv', flatfield_morphed)
+    np.save('output/flatfield_'+channel+'_HSM.npy', flatfield_morphed)
     #pickle the flatfields
-    pickle.dump(flatfield_morphed, open('output/flatfield_'+channel+'_HSM.pkl', 'wb'))
+    #pickle.dump(flatfield_morphed, open('output/flatfield_'+channel+'_HSM.pkl', 'wb'))
 
 
 

--- a/src/database_generation/run_make_flatfield.py
+++ b/src/database_generation/run_make_flatfield.py
@@ -12,6 +12,7 @@ This script produced morfed images between the flatfield without baffle taken at
 import numpy as np
 from database_generation import flatfield as flatfield
 from pathlib import Path
+import pickle
 
 #import sys
 #sys.path.append('/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/src/database_generation')
@@ -27,8 +28,11 @@ for channel in channels:
      #Note, only using HSM mode images for making flatfield now LM230925
     flatfield_morphed=flatfield.make_flatfield(channel, calibration_file, plotresult=True, plotallplots=True)
     Path("output").mkdir(parents=True, exist_ok=True)
-    np.savetxt('output/flatfield_'+channel+'_HSM.csv', flatfield_morphed)
-    np.save('output/flatfield_'+channel+'_HSM.npy', flatfield_morphed)
+    #np.savetxt('output/flatfield_'+channel+'_HSM.csv', flatfield_morphed)
+    #np.save('output/flatfield_'+channel+'_HSM.npy', flatfield_morphed)
+    #pickle the flatfields
+    pickle.dump(flatfield_morphed, open('output/flatfield_'+channel+'_HSM.pkl', 'wb'))
+
 
 
 #

--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -655,8 +655,7 @@ def meanbin_image_with_BC(CCDitem, image_nonbinned=None, error_flag_out=False):
     totbin = int(CCDitem["NRBIN"])*int(CCDitem["NCBIN CCDColumns"]) * \
         int(CCDitem["NCBIN FPGAColumns"])
     if nrskip+nbin_r*nrow > 511:
-        #Pad image with copies of the last row for when we are reading out row 513 to 515
-        image_nonbinned = np.pad(image_nonbinned, ((0, 3), (0, 0)), 'edge')
+        image_nonbinned=padlastrowsofimage(image_nonbinned,nrow)
     if (totbin > 1 or CCDitem["NCSKIP"] > 0 or CCDitem["NRSKIP"] > 0):
         image = image_nonbinned[nrskip:nrskip+nbin_r*nrow,
                                 CCDitem["NCSKIP"]:CCDitem["NCSKIP"]+nbin_c*ncol]
@@ -692,6 +691,10 @@ def meanbin_image_with_BC(CCDitem, image_nonbinned=None, error_flag_out=False):
     else:
         return meanbinned_image
 
+def padlastrowsofimage(image,nrow):
+    #Pad image with copies of the last row for when we are reading out row 513 to 515
+    image = np.pad(image, ((0, nrow), (0, 0)), 'edge')
+    return image
 
 def get_true_image(header, image=None):
     # calculate true image by removing readout offset (pixel blank value) and

--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -643,6 +643,8 @@ def meanbin_image_with_BC(CCDitem, image_nonbinned=None, error_flag_out=False):
     if image_nonbinned is None:
         image_nonbinned = CCDitem["IMAGE"]
 
+
+
     # Check if image needs to be binned or shifted
     nbin_c = int(CCDitem["NCBIN CCDColumns"])*int(CCDitem["NCBIN FPGAColumns"])
     nbin_r = int(CCDitem["NRBIN"])
@@ -653,7 +655,8 @@ def meanbin_image_with_BC(CCDitem, image_nonbinned=None, error_flag_out=False):
     totbin = int(CCDitem["NRBIN"])*int(CCDitem["NCBIN CCDColumns"]) * \
         int(CCDitem["NCBIN FPGAColumns"])
     if nrskip+nbin_r*nrow > 511:
-        nrskip = 511-nbin_r*nrow
+        #Pad image with copies of the last row for when we are reading out row 513 to 515
+        image_nonbinned = np.pad(image_nonbinned, ((0, 3), (0, 0)), 'edge')
     if (totbin > 1 or CCDitem["NCSKIP"] > 0 or CCDitem["NRSKIP"] > 0):
         image = image_nonbinned[nrskip:nrskip+nbin_r*nrow,
                                 CCDitem["NCSKIP"]:CCDitem["NCSKIP"]+nbin_c*ncol]

--- a/tests/calibration_data_test.toml
+++ b/tests/calibration_data_test.toml
@@ -2,32 +2,30 @@
 
 title = "Level 1 calibration files for testing this package"
 
+#Folders and parameters for generating the calibration database
+[primary_data]
+	folder = "/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/binning_test_20200812/RacFiles_out/"
 #Folders and parameters for performing calibration
 [darkcurrent]
-    folder = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/darkcurrent/"
-    dc_2D_limit = 0 
+	folder =  "/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/MATS_CCD_DC_calibration_FINAL/"
+    dc_2D_limit=0 #limit in counts above which 2D dark current subtraction is done
     default_temp = 0
 [flatfield]
-    flatfieldfolder = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/flatfields/"
-    flatfieldfolder_cold_unprocessed = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/20200330_flatfields_0C/"
-    baffle_flatfield = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/Flatfield20210421/PayloadImages/"
+	flatfieldfolder = "/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/flatfields/"
+	flatfieldfolder_cold_unprocessed = "/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/20200330_flatfields_0C/"
+	baffle_flatfield = "/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/Flatfield20210421/PayloadImages/"
 [linearity]
-    pixel = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/linearity/final/linearity_exp"
-    sumrow = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/linearity/final/linearity_row"
-    sumwell = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/linearity/final/linearity_col"
-    tables = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/linearity/tables/"
-[abs_rel_calib]
-    abs_rel_calib_constants= "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/abs_rel_calib/abs_rel_calib_constants.csv"
+    pixel = '/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/linearity/linear/linearity'
+    sumrow = '/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/linearity/linear/linearity'
+    sumwell = '/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/linearity/linear/linearity'
+    tables = '/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/linearity/tables/20220906/'
+[abs_rel_calib] 
+	abs_rel_calib_constants= "/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/abs_rel_calib/abs_rel_calib_constants.csv"
 [pointing]
-    qprime = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/pointing/"
+    qprime = '/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/pointing/'
 [artifact]
-    nadir = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/artifact/mask_op.pkl"
-    blank = "/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/artifact/blank.pkl"
+    nadir = '/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/artifact/mask_op.pkl'
+    blank = '/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/artifact/blank.pkl'
 [hot_pixels]
-    hot_pixels = '/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/hot_pixels/hpms.db'
-    single_events = '/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/hot_pixels/SE.db'
-[photometer]
-    thermistor_table = '/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/photometers/AlbedoFM_Thermistors_Temp_vs_bits.mat'
-    FM1_spline = '/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/photometers/SignFM1_Rad_raw.pkl' 
-    FM2_spline = '/home/olemar/Projects/Universitetet/MATS/MATS-L1-processing/calibration_data/photometers/SignFM2_Rad_raw.pkl' 
-
+    hot_pixels = '/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/Hotpixels/hpms.db'
+    single_events = '/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/calibration_data/Hotpixels/SE.db'

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -4,7 +4,7 @@ from mats_l1_processing.read_and_calibrate_all_files_parallel import main
 from mats_l1_processing.instrument import Instrument, CCD, Photometer
 from mats_l1_processing import photometer
 import pandas as pd
-from mats_l1_processing.L1_calibration_functions import inverse_model_real,inverse_model_table,make_binary,combine_flags,desmear,artifact_correction, correct_single_events,correct_hotpixels
+from mats_l1_processing.L1_calibration_functions import inverse_model_real,inverse_model_table,make_binary,combine_flags,desmear,artifact_correction, correct_single_events,correct_hotpixels, padlastrowsofimage
 from mats_l1_processing.L1_calibrate import L1_calibrate
 
 import pickle
@@ -427,12 +427,25 @@ def test_hp_correction():
 
     return 
 
+def test_image_padding():
+    with open('testdata/flatfield_IR2_HSM.pkl', 'rb') as f:
+        image = pickle.load(f)
+    [rows, colums]=image.shape
+    #print('shape of image',image.shape)
+    nrow=3
+    image_padded=padlastrowsofimage(image,nrow)
+    assert np.shape(image_padded)==(rows+nrow,colums), "Image padding shape mismatch"
+    assert np.all(image_padded[512:,:]==image_padded[511,:]), "Image padding values mismatch"
+    #print('shape of padded image',image_padded.shape)
 if __name__ == "__main__":
+    
 
     #test_calibrate()
-    test_calibrate_plots()
+    #test_calibrate_plots()
     #test_error_algebra()
     #test_channel_quaterion()
     #test_photometer()
     #test_hp_correction()
     #test_se_correction()
+    test_image_padding()
+# %%


### PR DESCRIPTION
Fixed bug in L1_calibration functions, meanbin_image_with_BC.  It used to bin the wrong area when nrskip+nbin_r*nrow > 511. Now padding the image with copies of the last row before binning.