### PR TITLE
Return errors when skipping steps

### DIFF
--- a/src/mats_l1_processing/L1_calibrate.py
+++ b/src/mats_l1_processing/L1_calibrate.py
@@ -112,4 +112,4 @@ def L1_calibrate(CCDitem, instrument, force_table: bool = True, return_steps=Fal
     if return_steps:
         return image_lsb, image_se_corrected, image_hot_pixel_corrected, image_bias_sub, image_linear, image_desmeared, image_dark_sub, image_flatfielded, image_flipped, image_calibrated, errors
     else:
-        return image_calibrated
+        return image_calibrated, errors


### PR DESCRIPTION
Return errors. This is not strictly necessary, but will make the interface in the Lambda neater.