### PR TITLE
changed where median filter of dark current was applied. to make code faster.

### DIFF
--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -553,7 +553,6 @@ def calculate_dark(CCDitem):
     Returns:
         dark_calc_image: Full frame dark current image for given CCD item.
     """
-    from scipy.ndimage import median_filter
     try:
         CCDunit = CCDitem["CCDunit"]
     except:
@@ -568,7 +567,7 @@ def calculate_dark(CCDitem):
 
     # Then based on how large the dark current is , decide on whether to use 0D or 2D subtraction
     if totdarkcurrent0D.mean() > CCDunit.dc_2D_limit:
-        totdarkcurrent = median_filter(totdarkcurrent2D, size=3)
+        totdarkcurrent = totdarkcurrent2D
     else:
         totdarkcurrent = totdarkcurrent0D.mean() * np.ones(totdarkcurrent2D.shape)
 

--- a/src/mats_l1_processing/instrument.py
+++ b/src/mats_l1_processing/instrument.py
@@ -18,6 +18,7 @@ import scipy.io
 from scipy.io import loadmat
 import sqlite3 as sqlite
 from datetime import datetime
+from scipy.ndimage import median_filter
 
 class CCD:
     """Class to represent a single physical CCD on MATS, a.k.a CCDunit
@@ -205,15 +206,16 @@ class CCD:
         self.log_b_std_LSM = mat["log_b_std_LSM"]
 
         # 2D dark current subtraction stuff
-        self.log_a_img_avr_LSM = mat["log_a_img_avr_LSM"]
-        self.log_a_img_err_LSM = mat["log_a_img_err_LSM"]
-        self.log_b_img_avr_LSM = mat["log_b_img_avr_LSM"]
-        self.log_b_img_err_LSM = mat["log_b_img_err_LSM"]
+        self.log_a_img_avr_LSM = median_filter(mat["log_a_img_avr_LSM"], size=3)
+        self.log_a_img_err_LSM = median_filter(mat["log_a_img_err_LSM"], size=3)
+        self.log_b_img_avr_LSM = median_filter(mat["log_b_img_avr_LSM"], size=3)
+        self.log_b_img_err_LSM = median_filter(mat["log_b_img_err_LSM"], size=3)
 
-        self.log_a_img_avr_HSM = mat["log_a_img_avr_HSM"]
-        self.log_a_img_err_HSM = mat["log_a_img_err_HSM"]
-        self.log_b_img_avr_HSM = mat["log_b_img_avr_HSM"]
-        self.log_b_img_err_HSM = mat["log_b_img_err_HSM"]
+        self.log_a_img_avr_HSM = median_filter(mat["log_a_img_avr_HSM"], size=3)
+        self.log_a_img_err_HSM = median_filter(mat["log_a_img_err_HSM"], size=3)
+        self.log_b_img_avr_HSM = median_filter(mat["log_b_img_avr_HSM"], size=3)
+        self.log_b_img_err_HSM = median_filter(mat["log_b_img_err_HSM"], size=3)
+
 
         # Flatfields
         if channel=="NADIR":


### PR DESCRIPTION
changed so that median filter of dark current was applied to the two coefficients of the linear fit  ( darkcurrent =

10 ** (self.log_a_img_avr_HSM * T + self.log_b_img_avr_HSM) see darkcurrent2d in instrument.py) instead of to the final dark current. This was done in order to get faster processing since the median filter is now only applied when the CCD of the instrument is initiated.