### PR TITLE
Flatfield avarages2

### DIFF
--- a/src/database_generation/flatfield.py
+++ b/src/database_generation/flatfield.py
@@ -11,7 +11,7 @@ import toml
 
 
 
-def read_flatfield(CCDunit, mode, flatfield_directory):
+def read_flatfield(CCDunit, mode, flatfield_directory, reporterror=False):
     from mats_l1_processing.items_units_functions import (
         read_files_in_protocol_as_ItemsUnits,
     )
@@ -66,23 +66,32 @@ def read_flatfield(CCDunit, mode, flatfield_directory):
         for i in range(1, len(CCDItemsUnitsSelect)): #the first image is not used since it is weird for unknown reasons
             flatfieldtmp = CCDItemsUnitsSelect[i].subpic
             if flatfieldtmp.mean()>signalmin and flatfieldtmp.mean()<signalmax:
-                flatfieldlist.append(CCDItemsUnitsSelect[i].subpic/(CCDItemsUnitsSelect[i].imageItem["TEXPMS"]/1000.))  # Append to flatfieldlist
+                #flatfieldlist.append(CCDItemsUnitsSelect[i].subpic/(CCDItemsUnitsSelect[i].imageItem["TEXPMS"]/1000.))  # Append to flatfieldlist
+                flatfieldlist.append(scale_field(flatfieldtmp)) # Append flatfield scaled to unity in the middle to flatfieldlist
                 #print('i=',i,'channel:', CCDItemsUnitsSelect[i].imageItem["channel"])
                 #plot_CCDimage(CCDItemsUnitsSelect[i].subpic, title='flatfieldlist[i]'+str(i)+ 'texpms'+str(CCDItemsUnitsSelect[i].imageItem["TEXPMS"]/1000.))
  
         try:
             flatfield = np.array(flatfieldlist).mean(axis=0)
+            flatfielderr = np.array(flatfieldlist).std(axis=0)/np.sqrt(len(flatfieldlist))
+            
         except:
             Exception("No flatfield CCDItemUnit found - undefined flatfield")
             
+        #plot_CCDimage(flatfield, title='flatfield')
+        #plot_CCDimage(flatfielderr, title='flatfieldstd/sqrt(n)')
 
-    return flatfield
+    if reporterror:
+        return flatfield, flatfielderr
+    else:
+        return flatfield
 
 
 
 
 
-def scale_field(field):
+
+def scale_field(field, errorfield=None):
     # Now scale the average of the middle part of the flatfield with baffle
     # to be unity.
 
@@ -95,8 +104,11 @@ def scale_field(field):
     LastCol =1523
 
     field_scaled =field/field[FirstRow:LastRow, FirstCol + 1 : LastCol + 1].mean()
-
-    return field_scaled
+    if errorfield is not None:
+        errorfield_scaled =errorfield/field[FirstRow:LastRow, FirstCol + 1 : LastCol + 1].mean()
+        return field_scaled, errorfield_scaled
+    else:
+        return field_scaled
 
 #%%
     
@@ -166,17 +178,19 @@ def read_flatfield_w_baffle(calibration_file, channel):
         np.float64(Image.open(directory + dfile2 + ".pnm")))/2. # read dark background
 
 
-    flatfield_w_baffle = pic - picd
+    flatfield_w_baffle = scale_field(pic - picd)
 
     return flatfield_w_baffle
 
 
-def read_flatfield_wo_baffle(calibration_file, channel, sigmode='HSM'):
+def read_flatfield_wo_baffle(calibration_file, channel, sigmode='HSM', reporterror=False):
     CCDunit=CCD(channel,calibration_file)
     calibration_data=toml.load(calibration_file)
-    flatfield_wo_baffle = read_flatfield(CCDunit, sigmode, calibration_data["flatfield"]["flatfieldfolder_cold_unprocessed"])
- 
-    return flatfield_wo_baffle
+    flatfield_wo_baffle, flatfield_wo_baffle_err = read_flatfield(CCDunit, sigmode, calibration_data["flatfield"]["flatfieldfolder_cold_unprocessed"], reporterror=True)
+    if reporterror:
+        return flatfield_wo_baffle, flatfield_wo_baffle_err
+    else:
+        return flatfield_wo_baffle
 
 
 def select_edge_of_baffle_by_plotting(diff_field,zs, plot=True):
@@ -360,34 +374,42 @@ def scalefieldtoedgevalue(ratiofield, colstart, colstop, rowstart, rowstop, nnpi
 #%%
 
 def make_flatfield(channel, calibration_file, plotresult=False, plotallplots=False):
+    #Readis in flatfields with and without baffle and morphs them together to create an articicial flatfield with baffle.
+    # Returns the morphed flatfield, the std error of the flatfield without baffle, 
+    # and a field that shows the effect of the baffle compensation added to the flatfield without baffle
+    
     import mats_l1_processing
     from database_generation.sgolay2 import SGolayFilter2
     from scipy.signal import medfilt
 
     #Note the high signal mode flatfields are used even if in low signal mode. They are scaled to be 1 in the middle of the field anyway.
-    flatfield_wo_baffle=read_flatfield_wo_baffle(calibration_file, channel, sigmode='HSM')
+    #Now both fields are scaled to unity in the middle when read in. 
+    flatfield_wo_baffle, flatfield_wo_baffle_err=read_flatfield_wo_baffle(calibration_file, channel, sigmode='HSM', reporterror=True)
     flatfield_w_baffle=read_flatfield_w_baffle(calibration_file, channel)
-    # Remove hot pixels by applying a median filter to every row in the 2D array
-    flatfield_s_wo_baffle = flatfield_wo_baffle #Do  not apply median filter to the flatfield without baffle
-    flatfield_s_w_baffle = np.apply_along_axis(lambda x: medfilt(x, kernel_size=3), axis=1, arr=flatfield_w_baffle)       
-    
 
+
+    # Remove hot pixels by applying a median filter to every row in the 2D array, and rescale. 
+    # Only done for w baffle wo is constructed from means and will not be smoothed.
+    flatfield_s_wo_baffle = flatfield_wo_baffle #Do  not apply median filter to the flatfield without baffle since this is the average
+    flatfield_s_w_baffle = np.apply_along_axis(lambda x: medfilt(x, kernel_size=3), axis=1, arr=flatfield_w_baffle)  
+
+         
+    
+    #Rescale fields aftertaken mean / median filter. Should not make much diffrence (none at all for the mean filter i.e. wo baffle )
     flatfield_wo_baffle_scaled=scale_field(flatfield_s_wo_baffle)
     flatfield_w_baffle_scaled=scale_field(flatfield_s_w_baffle)
+
     ratio_w_to_wo_scaled=flatfield_w_baffle_scaled/flatfield_wo_baffle_scaled
     zs = SGolayFilter2(window_size=31, poly_order=1)(ratio_w_to_wo_scaled)
     grad2d=select_edge_of_baffle_by_plotting(ratio_w_to_wo_scaled,zs, plot=plotallplots)
 
-
-
-
     colstart, colstop, rowstart, rowstop=define_edge_of_baffle(channel) #Note: a manual selection is needed based on select_edge_of_baffle_by_plotting
-    scalefield=scalefieldtoedgevalue(zs, colstart, colstop, rowstart, rowstop, nnpix=2, npix=50)
+    baffle_scalefield=scalefieldtoedgevalue(zs, colstart, colstop, rowstart, rowstop, nnpix=2, npix=50)
 
-    flatfield=scalefield*flatfield_wo_baffle_scaled
+    flatfield=baffle_scalefield*flatfield_wo_baffle_scaled
 
 
-
+    
     if plotresult:
         fig, ax = plt.subplots(6,2, figsize=[8,14])
         plot_CCDimage(flatfield_wo_baffle,fig, ax[0,0], title=channel+' wo baffle')
@@ -400,7 +422,7 @@ def make_flatfield(channel, calibration_file, plotresult=False, plotallplots=Fal
         plot_CCDimage(flatfield_w_baffle_scaled,fig, ax[2,1], title=channel+ 'w flatfield scaled')
         plot_CCDimage(ratio_w_to_wo_scaled,fig, ax[3,0], title=channel+' ratio btw scaled w and scaled wo ')
         plot_CCDimage(zs,fig, ax[3,1], clim=[0.7, 1.1], title=channel+' sav golay fit')
-        plot_CCDimage(scalefield,fig, ax[4,0], clim=[0.7, 1.1], title=channel+' scalefield')
+        plot_CCDimage(baffle_scalefield,fig, ax[4,0], clim=[0.7, 1.1], title=channel+' scalefield')
         plot_CCDimage(flatfield,fig, ax[4,1], title=channel+' merged flatfield')
         plot_CCDimage(flatfield_wo_baffle_scaled-flatfield,fig, ax[5,0], title='difference wo flatfield -  merged flatfield')
         plot_CCDimage(flatfield_w_baffle_scaled-flatfield,fig, ax[5,1], title='difference w flatfield - merged flatfield')
@@ -408,11 +430,15 @@ def make_flatfield(channel, calibration_file, plotresult=False, plotallplots=Fal
         Path("output").mkdir(parents=True, exist_ok=True)
         fig.savefig("output/Merged_Flatfield_" + channel + ".jpg")
 
-        # figS, axS = plt.subplots(2,1)
-        # plot_CCDimage(flatfield, figS, axS[0],title=channel+' smoothed')
-        # plot_CCDimage(smooth_flatfield, figS, axS[1],title=channel+' smoothed')
+        figS, axS = plt.subplots(3,1, figsize=[5,6])
+        plot_CCDimage(flatfield_wo_baffle, figS, axS[0],title=channel+' Flatfield without baffle')
+        plot_CCDimage(flatfield_w_baffle, figS, axS[1],title=channel+' Flatfield with baffle')
+        plot_CCDimage(flatfield, figS, axS[2],title=channel+' Flatfield merged')
+        plt.tight_layout()
+        fig.savefig("output/Flatfield_w_wo_merged_" + channel + ".jpg")
 
-    return flatfield
+
+    return flatfield, flatfield_wo_baffle_err, baffle_scalefield
 
 
 

--- a/src/database_generation/run_make_flatfield.py
+++ b/src/database_generation/run_make_flatfield.py
@@ -20,7 +20,7 @@ import pickle
 calibration_file='/Users/lindamegner/MATS/MATS-retrieval/MATS-analysis/Linda/calibration_data_linda.toml'
 
 
-channels=['IR4','IR2','IR3','IR4','UV1','UV2']#,'NADIR' ]
+channels=['IR1','IR2','IR3','IR4','UV1','UV2']#,'NADIR' ]
 
 
 

--- a/src/database_generation/run_make_flatfield.py
+++ b/src/database_generation/run_make_flatfield.py
@@ -13,6 +13,7 @@ import numpy as np
 from database_generation import flatfield as flatfield
 from pathlib import Path
 import pickle
+from database_generation.experimental_utils import plot_CCDimage
 
 #import sys
 #sys.path.append('/Users/lindamegner/MATS/MATS-retrieval/MATS-L1-processing/src/database_generation')
@@ -26,17 +27,29 @@ channels=['IR1','IR2','IR3','IR4','UV1','UV2']#,'NADIR' ]
 
 for channel in channels:
      #Note, only using HSM mode images for making flatfield now LM230925
-    flatfield_morphed=flatfield.make_flatfield(channel, calibration_file, plotresult=True, plotallplots=True)
+    flatfield_morphed, flatfield_wo_baffle_err, baffle_scalefield=flatfield.make_flatfield(channel, calibration_file, plotresult=True, plotallplots=True)
     Path("output").mkdir(parents=True, exist_ok=True)
     np.savetxt('output/flatfield_'+channel+'_HSM.csv', flatfield_morphed)
     np.save('output/flatfield_'+channel+'_HSM.npy', flatfield_morphed)
+    # The error measured as the standard deviation of three images divided by square root of 3
+    np.savetxt('output/flatfield_wo_baffle_err_scaled_'+channel+'_HSM.csv', flatfield_wo_baffle_err)
+    np.save('output/flatfield_wo_baffle_err_'+channel+'_HSM.npy', flatfield_wo_baffle_err)
+    # The baffle scalefield, where 1 means no effect, ie the flatfield is the 
+    # same as the one without baffle. 
+    np.savetxt('output/baffle_scalefield_'+channel+'_HSM.csv', baffle_scalefield)
+    np.save('output/baffle_scalefield_'+channel+'_HSM.npy', baffle_scalefield)
+
+
+    plot_CCDimage(flatfield_morphed, title='Flatfield '+channel)
+    plot_CCDimage(flatfield_wo_baffle_err, title='Flatfield wo error '+channel)
+    plot_CCDimage(baffle_scalefield, title='Baffe scalefield '+channel)
+
+
+
     #pickle the flatfields
     #pickle.dump(flatfield_morphed, open('output/flatfield_'+channel+'_HSM.pkl', 'wb'))
 
 
-
-#
-    
 
 
 # %%


### PR DESCRIPTION
changed so that flat fields without baffle are read in as the mean from 3 different images with different integration time, instead of from only one image.
Added 2 error fields: the std/(sqrt(N) of the three fields to desctibe the statistical error in the flatfield without baffle, and baffle-scalefield which is what the nonbaffled field are multiplied with to the the merged fields.
