### PR TITLE
temperatuere set to average of uv1 and uv2 in read_parquet

### DIFF
--- a/src/mats_l1_processing/read_parquet_functions.py
+++ b/src/mats_l1_processing/read_parquet_functions.py
@@ -122,11 +122,11 @@ def add_ccd_item_attributes(ccd_data: DataFrame) -> None:
     ADC_temp_in_degreeC = 1.0 / 0.85 * ADC_temp_in_mV - 296
     ccd_data["temperature_ADC"] = ADC_temp_in_degreeC
 
-    # This needs to be updated when a better temperature estimate has been
-    # designed. For now a de facto implementation of
+    # For now the temperatures of all CCDs are set to the average between
+    # UV1 and UV2 as implementated in
     # get_temperature.add_temperature_info()
-    ccd_data["temperature"] = ccd_data["HTR8A"]
-    ccd_data["temperature_HTR"] = ccd_data["HTR8A"]
+    ccd_data["temperature"] = (ccd_data["HTR8A"]+ccd_data["HTR8B"]) / 2.0
+    ccd_data["temperature_HTR"] = (ccd_data["HTR8A"]+ccd_data["HTR8B"]) / 2.0
 
 
 def remove_faulty_rows(


### PR DESCRIPTION
Changed to that the tempreature of all CCDs are set to the average between the ones
measured close to UV1 and UV2. This was not compliant with other parts of the code where this was updated and pushed about a month ago. I am not sure where this _read_parquet_funtion is used.
 # Please enter the commit message for your changes. Lines starting