### PR TITLE
Bump dependencies

### DIFF
--- a/l1b_lambda/requirements.in
+++ b/l1b_lambda/requirements.in
@@ -2,7 +2,7 @@ build
 aws-cdk-lib
 aws-cdk.aws-lambda-python-alpha
 pandas
-pyarrow
+pyarrow>=14.0.0
 joblib
 scipy
 toml

--- a/l1b_lambda/requirements.txt
+++ b/l1b_lambda/requirements.txt
@@ -97,7 +97,7 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-pyarrow==10.0.1
+pyarrow==15.0.0
     # via -r requirements.in
 pyparsing==3.0.9
     # via matplotlib

--- a/src/mats_l1_processing/read_parquet_functions.py
+++ b/src/mats_l1_processing/read_parquet_functions.py
@@ -277,17 +277,17 @@ def read_ccd_data_in_interval(
     """
 
     if start.tzinfo is None:
-        start.replace(tzinfo=timezone.utc)
+        start = start.replace(tzinfo=timezone.utc)
     if stop.tzinfo is None:
-        stop.replace(tzinfo=timezone.utc)
+        stop = stop.replace(tzinfo=timezone.utc)
 
     partitioning = ds.partitioning(
         schema=pa.schema(
             [
-                ("year", pa.int16()),
-                ("month", pa.int8()),
-                ("day", pa.int8()),
-                ("hour", pa.int8()),
+                ("year", pa.int32()),
+                ("month", pa.int32()),
+                ("day", pa.int32()),
+                ("hour", pa.int32()),
             ]
         ),
     )
@@ -321,7 +321,6 @@ def read_ccd_data_in_interval(
         + stop_with_margin.hour
     )
 
-
     filterlist = (
         (ds.field("EXPDate") >= Timestamp(start))
         & (ds.field("EXPDate") <= Timestamp(stop))
@@ -333,7 +332,7 @@ def read_ccd_data_in_interval(
                     (ds.field(variable) >= value[0])
                     & (ds.field(variable) <= value[1])
                 )
-            elif type(value) in [int,str,float,bool]:
+            elif type(value) in (int, str, float, bool):
                 filterlist &= (
                     (ds.field(variable) == value)                    
                 ) 
@@ -344,12 +343,12 @@ def read_ccd_data_in_interval(
 
     if dataframe.index.name == 'EXPDate':
         dataframe.reset_index(inplace=True)
-        dataframe.set_index('TMHeaderTime',inplace=True)
+        dataframe.set_index('TMHeaderTime', inplace=True)
         dataframe.sort_index(inplace=True)
         dataframe.reset_index(inplace=True)
     else:
-        dataframe.reset_index(drop=True,inplace=True)
-        dataframe.set_index('TMHeaderTime',inplace=True)
+        dataframe.reset_index(drop=True, inplace=True)
+        dataframe.set_index('TMHeaderTime', inplace=True)
         dataframe.sort_index(inplace=True)
         dataframe.reset_index(inplace=True)
 
@@ -390,16 +389,16 @@ def read_instrument_data_in_interval(
     """
 
     if start.tzinfo is None:
-        start.replace(tzinfo=timezone.utc)
+        start = start.replace(tzinfo=timezone.utc)
     if stop.tzinfo is None:
-        stop.replace(tzinfo=timezone.utc)
+        stop = stop.replace(tzinfo=timezone.utc)
 
     partitioning = ds.partitioning(
         schema=pa.schema(
             [
-                ("year", pa.int16()),
-                ("month", pa.int8()),
-                ("day", pa.int8()),
+                ("year", pa.int32()),
+                ("month", pa.int32()),
+                ("day", pa.int32()),
             ]
         ),
     )
@@ -431,8 +430,8 @@ def read_instrument_data_in_interval(
 
 
     filterlist = (
-        (ds.field("TMHeaderTime") >= Timestamp(start))
-        & (ds.field("TMHeaderTime") <= Timestamp(stop))
+        (ds.field("TMHeaderTime") >= pa.scalar(Timestamp(start)))
+        & (ds.field("TMHeaderTime") <= pa.scalar(Timestamp(stop)))
     )
     if filter != None:
         for variable, value in filter.items():
@@ -441,7 +440,7 @@ def read_instrument_data_in_interval(
                     (ds.field(variable) >= value[0])
                     & (ds.field(variable) <= value[1])
                 )
-            elif type(value) in [int,str,float,bool]:
+            elif type(value) in (int, str, float, bool):
                 filterlist &= (
                     (ds.field(variable) == value)                    
                 ) 
@@ -451,7 +450,7 @@ def read_instrument_data_in_interval(
 
     dataframe = table.to_pandas()
     dataframe.reset_index(inplace=True)
-    dataframe.set_index('TMHeaderTime',inplace=True)
+    dataframe.set_index('TMHeaderTime', inplace=True)
     dataframe.sort_index(inplace=True)
     dataframe.reset_index(inplace=True)
 


### PR DESCRIPTION
In this PR I:
- bump dependencies, most notably `PyArrow`,
- assure compatibility with `pyarrow>=14.0.0` has been assured by tweaking the partitioning filter to use a bigger `int` size (using the minimal sizes cast the result to the lower size, causing overflow error),
- fix a bug in `read_parquet_functions.py` that did not properly enforce timezone has been fixed. The corresponding logic can now be removed from MATS Utilities,
- implement minor code style fixes.

# Note that versions `12.x.x` and `13.x.x` have a bug in how timestamps are implemented and cannot be used with our dataset. These versions cannot and will not be supported!

Resolves #149 