### PR TITLE
Removing flagging when  (np.any((image_desmear/image) > 1.)) or (np.m…

### DIFF
--- a/src/mats_l1_processing/L1_calibration_functions.py
+++ b/src/mats_l1_processing/L1_calibration_functions.py
@@ -731,14 +731,9 @@ def desmear_true_image(header, image=None, **kwargs):
         error_flag_gamma = error_flag_gamma + 1
         image = image
     else:
-        image_desmear = desmear(image, nrextra=fill_function.shape[0], exptimeratio=T_row_extra /
+        image = desmear(image, nrextra=fill_function.shape[0], exptimeratio=T_row_extra /
                     T_exposure, fill=fill_array)
 
-        if (np.any((image_desmear/image) > 1.)) or (np.mean(image_desmear)/np.mean(image) < 0.25): #Sanity check of desmearing
-            error_flag_gamma = error_flag_gamma + 1
-            image = image
-        else:
-            image=image_desmear
             
     # Flag for negative values
     error_flag_negative = np.zeros(image.shape, dtype=np.uint16)


### PR DESCRIPTION
…ean(image_desmear)/np.mean(image) < 0.25)  so that these images are desmeared as ordinary images.